### PR TITLE
Update Coinbase to API v2

### DIFF
--- a/DataModule/src/com/mobnetic/coinguardian/model/market/Coinbase.java
+++ b/DataModule/src/com/mobnetic/coinguardian/model/market/Coinbase.java
@@ -1,213 +1,67 @@
 package com.mobnetic.coinguardian.model.market;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-
-import org.json.JSONObject;
-
 import com.mobnetic.coinguardian.model.CheckerInfo;
+import com.mobnetic.coinguardian.model.CurrencyPairInfo;
 import com.mobnetic.coinguardian.model.Market;
 import com.mobnetic.coinguardian.model.Ticker;
-import com.mobnetic.coinguardian.model.currency.Currency;
 import com.mobnetic.coinguardian.model.currency.VirtualCurrency;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.List;
 
 public class Coinbase extends Market {
 
 	private final static String NAME = "Coinbase";
 	private final static String TTS_NAME = NAME;
-	private final static String URL = "https://coinbase.com/api/v1/prices/buy?currency=%1$s";
-	private final static String URL_SECOND = "https://coinbase.com/api/v1/prices/sell?currency=%1$s";
-	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
-	
-	static {
-		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{
-				Currency.USD
-//				Currency.EUR,
-//				Currency.CHF,
-//				Currency.GBP,
-//				Currency.CAD,
-//				Currency.CNY,
-//				Currency.RUB,
-//				Currency.JPY,
-//				Currency.AUD,
-//				Currency.AFN,
-//				Currency.ALL,
-//				Currency.DZD,
-//				Currency.AOA,
-//				Currency.ARS,
-//				Currency.AMD,
-//				Currency.AWG,
-//				Currency.AZN,
-//				Currency.BSD,
-//				Currency.BHD,
-//				Currency.BDT,
-//				Currency.BBD,
-//				Currency.BYR,
-//				Currency.BZD,
-//				Currency.BMD,
-//				Currency.BTN,
-//				Currency.BOB,
-//				Currency.BAM,
-//				Currency.BWP,
-//				Currency.BRL,
-//				Currency.BND,
-//				Currency.BGN,
-//				Currency.BIF,
-//				Currency.KHR,
-//				Currency.CVE,
-//				Currency.KYD,
-//				Currency.XAF,
-//				Currency.XPF,
-//				Currency.CLP,
-//				Currency.COP,
-//				Currency.KMF,
-//				Currency.CDF,
-//				Currency.CRC,
-//				Currency.HRK,
-//				Currency.CUP,
-//				Currency.CZK,
-//				Currency.DKK,
-//				Currency.DJF,
-//				Currency.DOP,
-//				Currency.XCD,
-//				Currency.EGP,
-//				Currency.ERN,
-//				Currency.EEK,
-//				Currency.ETB,
-//				Currency.FKP,
-//				Currency.FJD,
-//				Currency.GMD,
-//				Currency.GEL,
-//				Currency.GHS,
-//				Currency.GHS,
-//				Currency.GIP,
-//				Currency.GTQ,
-//				Currency.GNF,
-//				Currency.GYD,
-//				Currency.HTG,
-//				Currency.HNL,
-//				Currency.HKD,
-//				Currency.HUF,
-//				Currency.ISK,
-//				Currency.INR,
-//				Currency.IDR,
-//				Currency.IRR,
-//				Currency.IQD,
-//				Currency.ILS,
-//				Currency.JMD,
-//				Currency.JOD,
-//				Currency.KZT,
-//				Currency.KES,
-//				Currency.KWD,
-//				Currency.KGS,
-//				Currency.LAK,
-//				Currency.LVL,
-//				Currency.LBP,
-//				Currency.LSL,
-//				Currency.LRD,
-//				Currency.LYD,
-//				Currency.LTL,
-//				Currency.MOP,
-//				Currency.MKD,
-//				Currency.MGA,
-//				Currency.MWK,
-//				Currency.MYR,
-//				Currency.MVR,
-//				Currency.MRO,
-//				Currency.MUR,
-//				Currency.MXN,
-//				Currency.MDL,
-//				Currency.MNT,
-//				Currency.MAD,
-//				Currency.MZN,
-//				Currency.MMK,
-//				Currency.NAD,
-//				Currency.NPR,
-//				Currency.ANG,
-//				Currency.TWD,
-//				Currency.NZD,
-//				Currency.NIO,
-//				Currency.NGN,
-//				Currency.KPW,
-//				Currency.NOK,
-//				Currency.OMR,
-//				Currency.PKR,
-//				Currency.PAB,
-//				Currency.PGK,
-//				Currency.PYG,
-//				Currency.PEN,
-//				Currency.PHP,
-//				Currency.PLN,
-//				Currency.QAR,
-//				Currency.RON,
-//				Currency.RWF,
-//				Currency.SHP,
-//				Currency.SVC,
-//				Currency.WST,
-//				Currency.SAR,
-//				Currency.RSD,
-//				Currency.SCR,
-//				Currency.SLL,
-//				Currency.SGD,
-//				Currency.SBD,
-//				Currency.SOS,
-//				Currency.ZAR,
-//				Currency.KRW,
-//				Currency.LKR,
-//				Currency.SDG,
-//				Currency.SRD,
-//				Currency.SZL,
-//				Currency.SEK,
-//				Currency.SYP,
-//				Currency.STD,
-//				Currency.TJS,
-//				Currency.TZS,
-//				Currency.THB,
-//				Currency.TOP,
-//				Currency.TTD,
-//				Currency.TND,
-//				Currency.TRY,
-//				Currency.TMM,
-//				Currency.UGX,
-//				Currency.UAH,
-//				Currency.AED,
-//				Currency.UYU,
-//				Currency.UZS,
-//				Currency.VUV,
-//				Currency.VEF,
-//				Currency.VND,
-//				Currency.XOF,
-//				Currency.YER,
-//				Currency.ZMK,
-//				Currency.ZWL
-			});
-	}
-	
+
+	private final static String URL_CURRENCY_PAIRS = "https://api.coinbase.com/v2/currencies";
+
+	private final static String URL_TICKER_BUY = "https://api.coinbase.com/v2/prices/buy?currency=%1$s";
+	private final static String URL_TICKER_SELL = "https://api.coinbase.com/v2/prices/sell?currency=%1$s";
+
 	public Coinbase() {
-		super(NAME, TTS_NAME, CURRENCY_PAIRS);
+		super(NAME, TTS_NAME, null);
 	}
 
 	@Override
 	public int getNumOfRequests(CheckerInfo checkerInfo) {
 		return 2;
 	}
-	
+
 	@Override
 	public String getUrl(int requestId, CheckerInfo checkerInfo) {
-		if(requestId==0)
-			return String.format(URL, checkerInfo.getCurrencyCounter());
+		if (requestId == 0)
+			return String.format(URL_TICKER_BUY, checkerInfo.getCurrencyCounter());
 		else
-			return String.format(URL_SECOND, checkerInfo.getCurrencyCounter());
+			return String.format(URL_TICKER_SELL, checkerInfo.getCurrencyCounter());
 	}
-	
+
 	@Override
 	protected void parseTickerFromJsonObject(int requestId, JSONObject jsonObject, Ticker ticker, CheckerInfo checkerInfo) throws Exception {
-		JSONObject subtotal = jsonObject.getJSONObject("subtotal");
-		if(requestId==0) {
-			ticker.ask = subtotal.getDouble("amount");
-			ticker.last = subtotal.getDouble("amount");
+		JSONObject data = jsonObject.getJSONObject("data");
+		if (requestId == 0) {
+			ticker.ask = data.getDouble("amount");
+			ticker.last = data.getDouble("amount");
 		} else {
-			ticker.bid = subtotal.getDouble("amount");
+			ticker.bid = data.getDouble("amount");
 		}
 	}
+
+	@Override
+	public String getCurrencyPairsUrl(int requestId) {
+		return URL_CURRENCY_PAIRS;
+	}
+
+	@Override
+	protected void parseCurrencyPairsFromJsonObject(int requestId, JSONObject jsonObject, List<CurrencyPairInfo> pairs) throws Exception {
+		JSONArray data = jsonObject.getJSONArray("data");
+		for (int i = 0; i < data.length(); i++) {
+			JSONObject object = data.getJSONObject(i);
+			String currency = object.getString("id");
+			pairs.add(new CurrencyPairInfo(VirtualCurrency.BTC, currency, currency));
+		}
+	}
+
 }


### PR DESCRIPTION
Updates Coinbase to the current API version. This removes the static currency list in favor of downloading the supported currencies from the API.

Note: The Coinbase API v2 asks for an additional Header specifying the API version which is currently not possible with the provided interface (only query parameters are supported). This generates a warning in the response but does not break the response currently. Supporting custom headers would be a nice addtion.

Fixes #184.