### PR TITLE
Updated BitcoinAverage v2 API endpoint

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitcoinAverage.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitcoinAverage.java
@@ -15,7 +15,7 @@ public class BitcoinAverage extends Market {
 
 	private final static String NAME = "BitcoinAverage";
 	private final static String TTS_NAME = "Bitcoin Average";
-	private final static String URL = "https://api.bitcoinaverage.com/ticker/%1$s";
+	private final static String URL = "https://apiv2.bitcoinaverage.com/indices/global/%1$s";
 	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
 	static {
 		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{


### PR DESCRIPTION
Updated api endpoint from "https://api.bitcoinaverage.com/ticker/%1$s" to "https://apiv2.bitcoinaverage.com/indices/global/%1$s"