### PR TITLE
Updated Coinbase API url

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/Coinbase.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/Coinbase.java
@@ -18,8 +18,8 @@ public class Coinbase extends Market {
 
 	private final static String NAME = "Coinbase";
 	private final static String TTS_NAME = NAME;
-	private final static String URL = "https://api.exchange.coinbase.com/products/%1$s-%2$s/ticker";
-	private final static String URL_CURRENCY_PAIRS = "https://api.exchange.coinbase.com/products/";
+	private final static String URL = "https://api.gdax.com/products/%1$s-%2$s/ticker";
+	private final static String URL_CURRENCY_PAIRS = "https://api.gdax.com/products/";
 	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
 	
 	static {


### PR DESCRIPTION
Coinbase recently moved to https://api.gdax.com, disabling their old URL entirely, and breaking BitcoinChecker updates. This change is only to update the URL to the new one, kindly have a look and merge.