### PR TITLE
Update CexIO.java

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/CexIO.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/CexIO.java
@@ -18,67 +18,19 @@ public class CexIO extends Market {
 	private final static String URL = "https://cex.io/api/ticker/%1$s/%2$s";
 	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
 	static {
-		CURRENCY_PAIRS.put(VirtualCurrency.ANC, new String[]{
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.AUR, new String[]{
-				VirtualCurrency.BTC
-			});	
 		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{
 				Currency.USD,
-				Currency.EUR
+				Currency.EUR,
+				Currency.GBP,
+				Currency.RUB,
 			});
-		CURRENCY_PAIRS.put(VirtualCurrency.DGB, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.DOGE, new String[]{
+		CURRENCY_PAIRS.put(VirtualCurrency.ETH, new String[]{
 				Currency.USD,
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC,
-				Currency.EUR
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.DRK, new String[]{
-				Currency.USD,
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.FTC, new String[]{
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
+				Currency.EUR,	
+				VirtualCurrency.BTC		
 			});
 		CURRENCY_PAIRS.put(VirtualCurrency.GHS, new String[]{
-				Currency.USD,
 				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.IXC, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.LTC, new String[]{
-				Currency.USD,
-				Currency.EUR,
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.MEC, new String[]{
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.MYR, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.NMC, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.POT, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.USDE, new String[]{
-				VirtualCurrency.BTC
-			});
-		CURRENCY_PAIRS.put(VirtualCurrency.WDC, new String[]{
-				VirtualCurrency.BTC,
-				VirtualCurrency.LTC
 			});
 	}
 	


### PR DESCRIPTION
None of the following coins are being traded at CEX.IO: ANC, AUR, DGB, DOGE, DRK, FTC, IXC, MEC, MYR, NMC, POT, USDE, or WDC. 
Refer to supported coins at [Markets JSON URL](https://cex.io/api/tickers/USD/EUR/RUB/BTC/ETH/GHS/GBP)

However, this exchange offers trading BTC, ETH, and LTC. The latter (LTC) will will be decommissioned soon (Refer to their [blog](https://blog.cex.io/news/cex-io-announces-ltc-pairs-removal-16046))