### PR TITLE
Fix selection order of markets in dataTester.

### DIFF
--- a/dataModuleTester/src/main/java/com/mobnetic/coinguardiandatamodule/tester/MainActivity.java
+++ b/dataModuleTester/src/main/java/com/mobnetic/coinguardiandatamodule/tester/MainActivity.java
@@ -126,7 +126,9 @@ public class MainActivity extends Activity {
 	// Get selected items
 	// ====================
 	private Market getSelectedMarket() {
-		return MarketsConfigUtils.getMarketById(marketSpinner.getSelectedItemPosition());
+		int size = MarketsConfig.MARKETS.size();
+		int idx = (size - 1) - marketSpinner.getSelectedItemPosition();
+		return MarketsConfigUtils.getMarketById(idx);
 	}
 	
 	private String getSelectedCurrencyBase() {


### PR DESCRIPTION
8a198fc3 reversed the order of display, but they were
still being selected in the original order, causing confusion.