### PR TITLE
Add bitFlyer

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/config/MarketsConfig.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/config/MarketsConfig.java
@@ -124,5 +124,7 @@ public class MarketsConfig {
 		addMarket(new Urdubit());
 		addMarket(new NegocieCoins());
 		addMarket(new BitMEX());
+		addMarket(new BitFlyer());
+		addMarket(new BitFlyerFX());
 	}
 }

--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitFlyer.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitFlyer.java
@@ -1,0 +1,44 @@
+package com.mobnetic.coinguardian.model.market;
+
+import com.mobnetic.coinguardian.model.CheckerInfo;
+import com.mobnetic.coinguardian.model.Market;
+import com.mobnetic.coinguardian.model.Ticker;
+import com.mobnetic.coinguardian.model.currency.Currency;
+import com.mobnetic.coinguardian.model.currency.VirtualCurrency;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public class BitFlyer extends Market {
+
+	private final static String NAME = "bitFlyer";
+	private final static String TTS_NAME = "bit flyer";
+	private final static String URL = "https://api.bitflyer.jp/v1/ticker?product_code=%1$s_%2$s";
+	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<>();
+	static {
+		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{
+				Currency.JPY,
+			});
+		CURRENCY_PAIRS.put(VirtualCurrency.ETH, new String[]{
+				VirtualCurrency.BTC,
+			});
+	}
+
+	public BitFlyer() {
+		super(NAME, TTS_NAME, CURRENCY_PAIRS);
+	}
+	
+	@Override
+	public String getUrl(int requestId, CheckerInfo checkerInfo) {
+		return String.format(URL, checkerInfo.getCurrencyBase(), checkerInfo.getCurrencyCounter());
+	}
+	
+	@Override
+	protected void parseTickerFromJsonObject(int requestId, JSONObject jsonObject, Ticker ticker, CheckerInfo checkerInfo) throws Exception {
+		ticker.bid = jsonObject.getDouble("best_bid");
+		ticker.ask = jsonObject.getDouble("best_ask");
+		ticker.vol = jsonObject.getDouble("volume_by_product");
+		ticker.last = jsonObject.getDouble("ltp");
+	}
+}

--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitFlyerFX.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BitFlyerFX.java
@@ -1,0 +1,41 @@
+package com.mobnetic.coinguardian.model.market;
+
+import com.mobnetic.coinguardian.model.CheckerInfo;
+import com.mobnetic.coinguardian.model.Market;
+import com.mobnetic.coinguardian.model.Ticker;
+import com.mobnetic.coinguardian.model.currency.Currency;
+import com.mobnetic.coinguardian.model.currency.VirtualCurrency;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public class BitFlyerFX extends Market {
+
+	private final static String NAME = "bitFlyer FX";
+	private final static String TTS_NAME = "bit flyer FX";
+	private final static String URL = "https://api.bitflyer.jp/v1/ticker?product_code=FX_%1$s_%2$s";
+	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<>();
+	static {
+		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{
+				Currency.JPY,
+			});
+	}
+
+	public BitFlyerFX() {
+		super(NAME, TTS_NAME, CURRENCY_PAIRS);
+	}
+	
+	@Override
+	public String getUrl(int requestId, CheckerInfo checkerInfo) {
+		return String.format(URL, checkerInfo.getCurrencyBase(), checkerInfo.getCurrencyCounter());
+	}
+	
+	@Override
+	protected void parseTickerFromJsonObject(int requestId, JSONObject jsonObject, Ticker ticker, CheckerInfo checkerInfo) throws Exception {
+		ticker.bid = jsonObject.getDouble("best_bid");
+		ticker.ask = jsonObject.getDouble("best_ask");
+		ticker.vol = jsonObject.getDouble("volume_by_product");
+		ticker.last = jsonObject.getDouble("ltp");
+	}
+}


### PR DESCRIPTION
Add the Japanese exchange bitFlyer with BTC/JPY and ETH/BTC currency pairs. BTC/JPY is split between spot trading (bitFlyer Lightning) and margin trading (bitFlyer Lightning FX) so I added two different `Market` subclasses to cater for this. ETH/BTC is spot trading only.