### PR TITLE
Add Ethereum Classic and Ripple for BTCMarkets.net

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcMarkets.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcMarkets.java
@@ -25,7 +25,15 @@ public class BtcMarkets extends Market {
 				VirtualCurrency.BTC,
 				Currency.AUD
 			});
+		CURRENCY_PAIRS.put(VirtualCurrency.ETC, new String[]{
+				VirtualCurrency.BTC,
+				Currency.AUD
+			});
 		CURRENCY_PAIRS.put(VirtualCurrency.ETH, new String[]{
+				VirtualCurrency.BTC,
+				Currency.AUD
+			});
+		CURRENCY_PAIRS.put(VirtualCurrency.XRP, new String[]{
 				VirtualCurrency.BTC,
 				Currency.AUD
 			});


### PR DESCRIPTION
Add pairs for BTCMarket.net:
- ETC/AUD and ETC/BTC
- XRP/AUD and XRP/BTC
This addresses issue #369