### PR TITLE
Add support for Bitcoin Cash (BCH) on btcmarkets.net

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcMarkets.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcMarkets.java
@@ -37,6 +37,10 @@ public class BtcMarkets extends Market {
 				VirtualCurrency.BTC,
 				Currency.AUD
 			});
+		CURRENCY_PAIRS.put(VirtualCurrency.BCH, new String[]{
+				VirtualCurrency.BTC,
+				Currency.AUD
+			});
 	}
 	
 	public BtcMarkets() {


### PR DESCRIPTION
The request adds support for BCH/AUD and BCH/BTC on btcmarkets.net.

This merge resolves issue #424.