### PR TITLE
Migrated Coinsecure API from v0 to v1

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/CoinSecure.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/CoinSecure.java
@@ -15,7 +15,7 @@ public class CoinSecure extends Market {
 
 	private final static String NAME = "CoinSecure";
 	private final static String TTS_NAME = "Coin Secure";
-	private final static String URL = "https://api.coinsecure.in/v0/noauth/newticker";
+	private final static String URL = "https://api.coinsecure.in/v1/exchange/ticker";
 	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
 	static {
 		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{


### PR DESCRIPTION
Just updated API URL. API v1's JSON response is same as v0's.