### PR TITLE
Update BTCXIndia to use Ripple (XRP)

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcXIndia.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/BtcXIndia.java
@@ -19,7 +19,7 @@ public class BtcXIndia extends Market {
 	private final static String URL = "https://api.btcxindia.com/ticker";
 	private final static HashMap<String, CharSequence[]> CURRENCY_PAIRS = new LinkedHashMap<String, CharSequence[]>();
 	static {
-		CURRENCY_PAIRS.put(VirtualCurrency.BTC, new String[]{
+		CURRENCY_PAIRS.put(VirtualCurrency.XRP, new String[]{
 				Currency.INR
 			});
 	}


### PR DESCRIPTION
BTCXInida no longer supports BTC and has started to use XRP. This changeset is to reflect that change.