### PR TITLE
Fix for #609 : Currency positions reversed on the Koinex Exchange

### DIFF
--- a/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/Koinex.java
+++ b/dataModule/src/main/java/com/mobnetic/coinguardian/model/market/Koinex.java
@@ -52,7 +52,7 @@ public class Koinex extends Market {
 		final JSONObject currencyJSONObject = jsonObject.getJSONObject("stats");
 		final JSONArray currencyArray = currencyJSONObject.names();
 		for(int i=0; i<currencyArray.length(); ++i) {
-			pairs.add(new CurrencyPairInfo(Currency.INR, currencyArray.getString(i), null));
+			pairs.add(new CurrencyPairInfo(currencyArray.getString(i), Currency.INR, null));
 		}
 	}
 }


### PR DESCRIPTION
This will fix the issue #609 whereby the position of the currency symbols are wrong.